### PR TITLE
Added fix for verify message type in initialize errors iutrash

### DIFF
--- a/lib/braspag-rest/hashie/iutrash.rb
+++ b/lib/braspag-rest/hashie/iutrash.rb
@@ -31,7 +31,11 @@ module Hashie
     end
 
     def initialize_errors(errors)
-      @errors = errors.map { |error| { code: error['Code'], message: error['Message'] } }
+      if errors.is_a? [].class
+        @errors = errors.map { |error| { code: error['Code'], message: error['Message'] } }
+      else
+        @errors = errors['Errors'].map { |error| { code: error['Code'], message: error['Message'] } }
+      end
     end
   end
 end

--- a/spec/hashie/iutrash_spec.rb
+++ b/spec/hashie/iutrash_spec.rb
@@ -47,8 +47,8 @@ describe Hashie::IUTrash do
 
     it 'nested inverse attributes' do
       params['Telephones'] = [
-         { :code => '+55', :number => '555-555' },
-         { :code => '+1', :number => '222-222' }
+        { code: '+55', number: '555-555' },
+        { code: '+1', number: '222-222' }
       ]
       person = Person.new(params)
 

--- a/spec/payment_spec.rb
+++ b/spec/payment_spec.rb
@@ -349,9 +349,9 @@ describe BraspagRest::Payment do
     subject(:splitted_payment) { BraspagRest::Payment.new(splitted_credit_card_payment) }
 
     context 'when the gateway returns a successful response' do
-      let(:parsed_body) {
+      let(:parsed_body) do
         { 'Payment' => { 'Status' => 1, 'PaymentId' => '1ff114b4-32bb-4fe2-b1f2-ef79822ad5e1' } }
-      }
+      end
 
       let(:response) { double(success?: true, parsed_body: parsed_body) }
 
@@ -362,16 +362,35 @@ describe BraspagRest::Payment do
       end
     end
 
-    context 'when the gateway returns a failure' do
-      let(:parsed_body) {
+    context 'when the gateway returns a failure and the body is an Array' do
+      let(:parsed_body) do
         [{ 'Code' => 123, 'Message' => 'MerchantOrderId cannot be null' }]
-      }
+      end
 
       let(:response) { double(success?: false, parsed_body: parsed_body) }
 
       it 'returns false and fills the errors attribute' do
         expect(splitted_payment.split([split1, split2])).to be_falsey
-        expect(splitted_payment.errors).to eq([{ code: 123, message: "MerchantOrderId cannot be null" }])
+        expect(splitted_payment.errors).to eq([{ code: 123, message: 'MerchantOrderId cannot be null' }])
+      end
+    end
+
+    context 'when the gateway returns a failure and the body is a Hash' do
+      let(:parsed_body) do
+        {
+          'Errors' => [
+            {
+              'Message' => 'No one value can be negative'
+            }
+          ]
+        }
+      end
+
+      let(:response) { double(success?: false, parsed_body: parsed_body) }
+
+      it 'returns false and fills the errors attribute' do
+        expect(splitted_payment.split([split1, split2])).to be_falsey
+        expect(splitted_payment.errors).to eq([{ code: nil, message: 'No one value can be negative' }])
       end
     end
   end


### PR DESCRIPTION
Alter the method initialize errors in class iutrash and added the test method for gateway failure parse errors.