### PR TITLE
Alter split method for resolve NotCapturedError and NotSplittableError

### DIFF
--- a/lib/braspag-rest.rb
+++ b/lib/braspag-rest.rb
@@ -5,9 +5,10 @@ module BraspagRest
     @config
   end
 end
-
 require 'hashie'
 require 'rest-client'
+require 'braspag-rest/errors/not_captured_error'
+require 'braspag-rest/errors/not_splittable_payment_error'
 require 'braspag-rest/hashie'
 require 'braspag-rest/version'
 require 'braspag-rest/configuration'

--- a/lib/braspag-rest/errors/not_captured_error.rb
+++ b/lib/braspag-rest/errors/not_captured_error.rb
@@ -1,0 +1,3 @@
+module BraspagRest
+  class NotCapturedError < StandardError; end
+end

--- a/lib/braspag-rest/errors/not_splittable_payment_error.rb
+++ b/lib/braspag-rest/errors/not_splittable_payment_error.rb
@@ -1,0 +1,3 @@
+module BraspagRest
+  class NotSplittablePaymentError < StandardError; end
+end

--- a/lib/braspag-rest/payment.rb
+++ b/lib/braspag-rest/payment.rb
@@ -42,7 +42,6 @@ module BraspagRest
     property :authenticate, from: 'Authenticate'
     property :soft_descriptor, from: 'SoftDescriptor'
     property :fraud_analysis, from: 'FraudAnalysis'
-    property :is_splitted, from: 'IsSplitted'
 
     # Response fields
     property :received_date, from: 'ReceivedDate'
@@ -56,6 +55,9 @@ module BraspagRest
     coerce_key :split_payments, Array[BraspagRest::SplitPayment]
 
     def split(splits)
+      raise BraspagRest::NotSplittablePaymentError unless splitted?
+      raise BraspagRest::NotCapturedError unless captured?
+
       response = BraspagRest::Request.split(id, splits)
 
       if response.success?
@@ -63,10 +65,7 @@ module BraspagRest
       else
         initialize_errors(response.parsed_body) and return false
       end
-    end
-
-    def splitted?
-      is_splitted
+      true
     end
 
     def authorized?
@@ -83,6 +82,10 @@ module BraspagRest
 
     def refunded?
       status.to_i.eql?(STATUS_REFUNDED)
+    end
+
+    def splitted?
+      type == 'SplittedCreditCard'
     end
   end
 end

--- a/lib/braspag-rest/sale.rb
+++ b/lib/braspag-rest/sale.rb
@@ -4,6 +4,7 @@ module BraspagRest
 
     property :request_id, from: 'RequestId'
     property :order_id, from: 'MerchantOrderId'
+    property :is_splitted, from: 'IsSplitted'
     property :customer, from: 'Customer', with: ->(values) { BraspagRest::Customer.new(values) }
     property :payment, from: 'Payment', with: ->(values) { BraspagRest::Payment.new(values) }
 
@@ -66,6 +67,10 @@ module BraspagRest
       end
 
       self
+    end
+
+    def splitted?
+      payment.splitted?
     end
   end
 end

--- a/spec/payment_spec.rb
+++ b/spec/payment_spec.rb
@@ -40,7 +40,6 @@ describe BraspagRest::Payment do
       'Provider' => 'Simulado',
       'Currency' => 'BRL',
       'ProviderReturnMessage' => 'Operation Successful',
-      'IsSplitted' => false,
       'Amount' => 15_700,
       'BoletoNumber' => '2017091101',
       'CapturedAmount' => 15_800,
@@ -56,7 +55,7 @@ describe BraspagRest::Payment do
     }
   end
 
-  let(:splitted_credit_card_payment) do
+  let(:splitted_credit_card_payment_captured) do
     {
       'ReasonMessage' => 'Successful',
       'Interest' => 'ByMerchant',
@@ -98,7 +97,6 @@ describe BraspagRest::Payment do
       'Amount' => 15_700,
       'BoletoNumber' => '2017091101',
       'CapturedAmount' => 15_800,
-      'IsSplitted' => true,
       'Type' => 'SplittedCreditCard',
       'AuthorizationCode' => '058475',
       'PaymentId' => '1ff114b4-32bb-4fe2-b1f2-ef79822ad5e1',
@@ -107,7 +105,7 @@ describe BraspagRest::Payment do
       'Recurrent' => false,
       'VoidedAmount' => 1245,
       'VoidedDate' => '2015-06-25 10:18:32',
-      'Status' => 1,
+      'Status' => 2,
       'SplitPayments' => [
         {
           'SubordinateMerchantId' => '20943d1a-153f-42b6-93b8-07b9db000651',
@@ -145,6 +143,56 @@ describe BraspagRest::Payment do
             }
           ]
         }
+      ]
+    }
+  end
+
+  let(:splitted_credit_card_payment_authorized) do
+    {
+      'ServiceTaxAmount' => 0,
+      'Installments' => 1,
+      'Interest' => 0,
+      'Capture' => false,
+      'Authenticate' => false,
+      'Recurrent' => false,
+      'CreditCard' => {
+        'CardNumber' => '000000******0001',
+            'Holder' => 'Teste Holder',
+            'ExpirationDate' => '12/2021',
+            'SaveCard' => false,
+            'Brand' => 'Visa'
+      },
+      'Tid' => '1016101051753',
+      'ProofOfSale' => '1051753',
+      'AuthorizationCode' => '112504',
+      'Provider' => 'Simulado',
+      'SplitPayments' => [],
+      'Amount' => 10_000,
+      'ReceivedDate' => '2018-10-16 10:10:51',
+      'Status' => 1,
+      'IsSplitted' => true,
+      'ReturnMessage' => 'Operation Successful',
+      'ReturnCode' => '4',
+      'PaymentId' => 'c691daf5-a5cf-4e5c-82f8-3deaaaeeb13f',
+      'Type' => 'SplittedCreditCard',
+      'Currency' => 'BRL',
+      'Country' => 'BRA',
+      'Links' => [
+        {
+          'Method' => 'GET',
+          'Rel' => 'self',
+          'Href' => 'https://apiquerysandbox.cieloecommerce.cielo.com.br/1/sales/c691daf5-a5cf-4e5c-82f8-3deaaaeeb13f'
+        },
+            {
+              'Method' => 'PUT',
+              'Rel' => 'capture',
+              'Href' => 'https://apisandbox.cieloecommerce.cielo.com.br/1/sales/c691daf5-a5cf-4e5c-82f8-3deaaaeeb13f/capture'
+            },
+            {
+              'Method' => 'PUT',
+              'Rel' => 'void',
+              'Href' => 'https://apisandbox.cieloecommerce.cielo.com.br/1/sales/c691daf5-a5cf-4e5c-82f8-3deaaaeeb13f/void'
+            }
       ]
     }
   end
@@ -197,13 +245,11 @@ describe BraspagRest::Payment do
       expect(payment.authorization_code).to eq('058475')
       expect(payment.reason_code).to eq(0)
       expect(payment.reason_message).to eq('Successful')
-      expect(payment.is_splitted).to be_falsey
-      expect(payment).not_to be_splitted
     end
   end
 
   describe '.new_splitted' do
-    subject(:payment_splitted) { BraspagRest::Payment.new(splitted_credit_card_payment) }
+    subject(:payment_splitted) { BraspagRest::Payment.new(splitted_credit_card_payment_captured) }
 
     it 'initializes a splitted payment using braspag response format' do
       expect(payment_splitted.type).to eq('SplittedCreditCard')
@@ -213,15 +259,13 @@ describe BraspagRest::Payment do
       expect(payment_splitted.provider).to eq('Simulado')
       expect(payment_splitted.installments).to eq(1)
       expect(payment_splitted.credit_card).to be_an_instance_of(BraspagRest::CreditCard)
-      expect(payment_splitted.status).to eq(1)
+      expect(payment_splitted.status).to eq(2)
       expect(payment_splitted.id).to eq('1ff114b4-32bb-4fe2-b1f2-ef79822ad5e1')
       expect(payment_splitted.transaction_id).to eq('0625101832104')
       expect(payment_splitted.proof_of_sale).to eq('1832104')
       expect(payment_splitted.authorization_code).to eq('058475')
       expect(payment_splitted.reason_code).to eq(0)
       expect(payment_splitted.reason_message).to eq('Successful')
-      expect(payment_splitted.is_splitted).to be_truthy
-      expect(payment_splitted).to be_splitted
       expect(payment_splitted.split_payments[0].subordinate_merchant_id).to eq('20943d1a-153f-42b6-93b8-07b9db000651')
       expect(payment_splitted.split_payments[0].amount).to eq(6000)
       expect(payment_splitted.split_payments[0].fares.mdr).to eq(2)
@@ -344,63 +388,71 @@ describe BraspagRest::Payment do
       )
     end
 
-    before { allow(BraspagRest::Request).to receive(:split).and_return(response) }
+    context 'payment authorized' do
+      subject(:splitted_payment) { BraspagRest::Payment.new(splitted_credit_card_payment_authorized) }
 
-    subject(:splitted_payment) { BraspagRest::Payment.new(splitted_credit_card_payment) }
-
-    context 'when the gateway returns a successful response' do
-      let(:parsed_body) do
-        { 'Payment' => { 'Status' => 1, 'PaymentId' => '1ff114b4-32bb-4fe2-b1f2-ef79822ad5e1' } }
-      end
-
-      let(:response) { double(success?: true, parsed_body: parsed_body) }
-
-      it 'returns true and fills the sale object with the return' do
-        expect(splitted_payment.split([split1, split2])).to be_truthy
-        expect(splitted_payment.status).to eq(1)
-        expect(splitted_payment.id).to eq('1ff114b4-32bb-4fe2-b1f2-ef79822ad5e1')
+      it 'BraspagRest::NotCapturedError' do
+        expect { splitted_payment.split([split1, split2]) }.to raise_error(BraspagRest::NotCapturedError)
       end
     end
 
-    context 'when the gateway returns a failure and the body is an Array' do
-      let(:parsed_body) do
-        [{ 'Code' => 123, 'Message' => 'MerchantOrderId cannot be null' }]
-      end
+    context 'raises payment not of type SplittedCreditCard' do
+      subject(:splitted_payment) { BraspagRest::Payment.new(credit_card_payment) }
 
-      let(:response) { double(success?: false, parsed_body: parsed_body) }
-
-      it 'returns false and fills the errors attribute' do
-        expect(splitted_payment.split([split1, split2])).to be_falsey
-        expect(splitted_payment.errors).to eq([{ code: 123, message: 'MerchantOrderId cannot be null' }])
+      it 'raises BraspagRest::NotSplittablePaymentError' do
+        expect { splitted_payment.split([split1, split2]) }.to raise_error(BraspagRest::NotSplittablePaymentError)
       end
     end
 
-    context 'when the gateway returns a failure and the body is a Hash' do
-      let(:parsed_body) do
-        {
-          'Errors' => [
-            {
-              'Message' => 'No one value can be negative'
-            }
-          ]
-        }
+    context 'captured payment' do
+      before { allow(BraspagRest::Request).to receive(:split).and_return(response) }
+
+      subject(:splitted_payment) { BraspagRest::Payment.new(splitted_credit_card_payment_captured) }
+
+      context 'when the gateway returns a successful response' do
+        let(:parsed_body) do
+          { 'Payment' => { 'Status' => 2, 'PaymentId' => '1ff114b4-32bb-4fe2-b1f2-ef79822ad5e1' } }
+        end
+
+        let(:response) { double(success?: true, parsed_body: parsed_body) }
+
+        it 'returns true and fills the sale object with the return' do
+          expect(splitted_payment.split([split1, split2])).to be_truthy
+          expect(splitted_payment.status).to eq(2)
+          expect(splitted_payment.id).to eq('1ff114b4-32bb-4fe2-b1f2-ef79822ad5e1')
+        end
       end
 
-      let(:response) { double(success?: false, parsed_body: parsed_body) }
+      context 'when the gateway returns a failure and the body is an Array' do
+        let(:parsed_body) do
+          [{ 'Code' => 123, 'Message' => 'MerchantOrderId cannot be null' }]
+        end
 
-      it 'returns false and fills the errors attribute' do
-        expect(splitted_payment.split([split1, split2])).to be_falsey
-        expect(splitted_payment.errors).to eq([{ code: nil, message: 'No one value can be negative' }])
+        let(:response) { double(success?: false, parsed_body: parsed_body) }
+
+        it 'returns false and fills the errors attribute' do
+          expect(splitted_payment.split([split1, split2])).to be_falsey
+          expect(splitted_payment.errors).to eq([{ code: 123, message: 'MerchantOrderId cannot be null' }])
+        end
       end
-    end
-  end
 
-  describe '#splitted?' do
-    let(:payment) { BraspagRest::Payment.new(splitted_credit_card_payment) }
+      context 'when the gateway returns a failure and the body is a Hash' do
+        let(:parsed_body) do
+          {
+            'Errors' => [
+              {
+                'Message' => 'No one value can be negative'
+              }
+            ]
+          }
+        end
 
-    context 'when splitted' do
-      it 'returns splitted' do
-        expect(payment).to be_splitted
+        let(:response) { double(success?: false, parsed_body: parsed_body) }
+
+        it 'returns false and fills the errors attribute' do
+          expect(splitted_payment.split([split1, split2])).to be_falsey
+          expect(splitted_payment.errors).to eq([{ code: nil, message: 'No one value can be negative' }])
+        end
       end
     end
   end


### PR DESCRIPTION
Added Class Errors for NotCapturedError and NotSplittableError and removed method and fields is_splitted from payment and putted in Sale, and added tests in payment_spec for type of transaction (Spllited, CreditCard)